### PR TITLE
Update libraries, to work with python 3.10 or higher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ selenium-screenshot-*
 .idea
 **/geckodriver.log
 *venv/*
+venv/

--- a/bad-flask-app/app.py
+++ b/bad-flask-app/app.py
@@ -1,6 +1,7 @@
 import random
 from copy import deepcopy
-from flask import Flask, render_template, request, flash, Session, jsonify, make_response
+from flask import Flask, render_template, request, flash, jsonify, make_response
+from flask_session import Session
 from flask_restful import Resource, Api
 
 app = Flask(__name__, template_folder='templates')

--- a/bad-flask-app/requirements.txt
+++ b/bad-flask-app/requirements.txt
@@ -1,8 +1,9 @@
 Click==7.0
-Flask==1.0.2
+Flask==1.1.1
+Flask-Session==0.3.2
 Flask-RESTful==0.3.8
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.10.2
 MarkupSafe==1.1.0
 robot==20071211
-Werkzeug==0.14.1
+Werkzeug==0.16.0


### PR DESCRIPTION
This is necessary due to changes in collections.
BadFlaskApp is not importing directly from collections, but the libraries it relies on does.
In this pull request, libraries are updated to only as new as necessary to fix the issue (to reduce the risk of introducing more breaking changes). Bad Flask App opens and runs correctly in Firefox (on Linux) and in Google Chrome (on Windows).